### PR TITLE
Improve event-form schema

### DIFF
--- a/components/event-form.tsx
+++ b/components/event-form.tsx
@@ -38,22 +38,31 @@ type EventFormProps = {
   }
 }
 
+type EventFormDefaultValues = {
+  title: string
+  description?: string
+  location?: string
+  eventDate?: Date
+  capacity?: number
+}
+
 export function EventForm({ event }: EventFormProps) {
   const router = useRouter()
 
+  const defaultValues: EventFormDefaultValues = {
+    title: event?.title ?? '',
+    description: event?.description ?? '',
+    location: event?.location ?? '',
+    eventDate: event?.eventDate ?? undefined,
+    capacity: event?.capacity ?? undefined,
+  }
+
   const form = useForm({
-    defaultValues: {
-      title: event?.title ?? '',
-      description: event?.description ?? '',
-      location: event?.location ?? '',
-      eventDate: event?.eventDate ? formatDateTimeLocal(event.eventDate) : '',
-      capacity: event?.capacity ?? undefined,
-    },
+    defaultValues,
     validators: {
       onSubmit: EventFormSchema,
     },
     onSubmit: async ({ value }) => {
-      console.log(value)
       let res: EventFormActionResponse
 
       if (event) {
@@ -67,12 +76,12 @@ export function EventForm({ event }: EventFormProps) {
         res = await createEventAction(value)
       }
 
-      if (res.error) {
+      if (res?.error) {
         toast.error(res.error)
         return
       }
 
-      if (res.eventId) {
+      if (res?.eventId) {
         toast.success('Success')
         router.push(`/events/${res.eventId}`)
       }
@@ -208,9 +217,17 @@ export function EventForm({ event }: EventFormProps) {
                       type='datetime-local'
                       id={field.name}
                       name={field.name}
-                      value={field.state.value}
+                      value={
+                        field.state.value
+                          ? formatDateTimeLocal(field.state.value)
+                          : undefined
+                      }
                       onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
+                      onChange={(e) =>
+                        field.handleChange(
+                          e.target.value ? new Date(e.target.value) : undefined,
+                        )
+                      }
                       aria-invalid={isInvalid}
                     />
                     <FieldDescription>

--- a/components/event-form.tsx
+++ b/components/event-form.tsx
@@ -47,7 +47,7 @@ export function EventForm({ event }: EventFormProps) {
       description: event?.description ?? '',
       location: event?.location ?? '',
       eventDate: event?.eventDate ? formatDateTimeLocal(event.eventDate) : '',
-      capacity: event?.capacity?.toString() ?? '',
+      capacity: event?.capacity ?? undefined,
     },
     validators: {
       onSubmit: EventFormSchema,
@@ -180,7 +180,9 @@ export function EventForm({ event }: EventFormProps) {
                       name={field.name}
                       value={field.state.value}
                       onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
+                      onChange={(e) =>
+                        field.handleChange(e.target.valueAsNumber)
+                      }
                       aria-invalid={isInvalid}
                       placeholder='1000'
                       min='1'

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -22,7 +22,7 @@ export async function createEventAction({
   title: string
   description?: string
   location?: string
-  eventDate?: string
+  eventDate?: Date
   capacity?: number
 }): Promise<EventFormActionResponse> {
   const session = await auth.api.getSession({
@@ -47,17 +47,13 @@ export async function createEventAction({
     return { error: 'Invalid event data' }
   }
 
-  const normalizedEventDate = res.data.eventDate
-    ? new Date(res.data.eventDate)
-    : null
-
   const created = await prisma.event.create({
     data: {
       ownerUserId: userId,
       title: res.data.title,
       description: res.data.description || null,
       location: res.data.location || null,
-      eventDate: normalizedEventDate,
+      eventDate: res.data.eventDate,
       capacity: res.data.capacity,
     },
   })
@@ -77,7 +73,7 @@ export async function updateEventAction({
   title: string
   description?: string
   location?: string
-  eventDate?: string
+  eventDate?: Date
   capacity?: number
 }): Promise<EventFormActionResponse> {
   const session = await auth.api.getSession({
@@ -102,17 +98,13 @@ export async function updateEventAction({
     return { error: 'Invalid event data' }
   }
 
-  const normalizedEventDate = res.data.eventDate
-    ? new Date(res.data.eventDate)
-    : null
-
   const updated = await prisma.event.update({
     where: { ownerUserId: userId, id },
     data: {
       title: res.data.title,
       description: res.data.description || null,
       location: res.data.location || null,
-      eventDate: normalizedEventDate,
+      eventDate: res.data.eventDate,
       capacity: res.data.capacity,
     },
   })

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -23,7 +23,7 @@ export async function createEventAction({
   description?: string
   location?: string
   eventDate?: string
-  capacity?: string
+  capacity?: number
 }): Promise<EventFormActionResponse> {
   const session = await auth.api.getSession({
     headers: await headers(),
@@ -78,7 +78,7 @@ export async function updateEventAction({
   description?: string
   location?: string
   eventDate?: string
-  capacity?: string
+  capacity?: number
 }): Promise<EventFormActionResponse> {
   const session = await auth.api.getSession({
     headers: await headers(),

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -27,18 +27,10 @@ export const EventFormSchema = z.object({
   location: z.string(),
   eventDate: z.string(),
   capacity: z
-    .string()
-    .trim()
-    .refine((v) => v === '' || /^\d+$/.test(v), {
-      message: 'Capacity must be a number',
-    })
-    .refine((v) => v === '' || Number(v) > 0, {
-      message: 'Capacity must be greater than 0',
-    })
-    .refine((v) => v === '' || Number(v) <= 10_000, {
-      message: 'Capacity must be less than or equal to 10,000',
-    })
-    .transform((v) => (v === '' ? undefined : Number(v))),
+    .number('Capacity must be a number')
+    .int('Capacity must be a whole number')
+    .positive('Capacity must be greater than 0')
+    .max(10_000, 'Capacity must be less than or equal to 10,000'),
 })
 
 export const InviteRsvpFormSchema = z.object({

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -25,12 +25,13 @@ export const EventFormSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   description: z.string(),
   location: z.string(),
-  eventDate: z.string(),
+  eventDate: z.date().optional(),
   capacity: z
     .number('Capacity must be a number')
     .int('Capacity must be a whole number')
     .positive('Capacity must be greater than 0')
-    .max(10_000, 'Capacity must be less than or equal to 10,000'),
+    .max(10_000, 'Capacity must be less than or equal to 10,000')
+    .optional(),
 })
 
 export const InviteRsvpFormSchema = z.object({


### PR DESCRIPTION
Improved event-form schema:
- use number type for capacity (earlier was, string coerced to number)
- use Date type for eventDate (earlier was, string normalized to Date)